### PR TITLE
Headless background fetch + scheidingstekens

### DIFF
--- a/app/Magiscore/BackgroundFetchHeadlessTask.java
+++ b/app/Magiscore/BackgroundFetchHeadlessTask.java
@@ -1,0 +1,129 @@
+// Mensen met meer verstand van java zijn zeer welkom, om de code te verbeteren.
+
+package com.transistorsoft.cordova.backgroundfetch;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.IOException;
+import java.net.Socket;
+import org.json.*;
+import org.json.JSONObject;
+import java.lang.Object;
+import android.content.SharedPreferences;
+import com.transistorsoft.tsbackgroundfetch.BackgroundFetch;
+import com.transistorsoft.tsbackgroundfetch.BGTask;
+import android.util.Log;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import androidx.core.app.NotificationCompat;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.app.PendingIntent;
+import app.netlob.magiscore.R;
+
+public class BackgroundFetchHeadlessTask implements HeadlessTask {
+  @Override
+  public void onFetch(Context context, BGTask task) {
+    String taskId = task.getTaskId();
+    boolean isTimeout = task.getTimedOut();
+    if (isTimeout) {
+      Log.d(BackgroundFetch.TAG, "My BackgroundFetchHeadlessTask TIMEOUT: " + taskId);
+      BackgroundFetch.getInstance(context).finish(taskId);
+      return;
+    }
+    Log.d(BackgroundFetch.TAG, "My BackgroundFetchHeadlessTask:  onFetch: " + taskId);
+    // Perform your work here....
+    Thread thread = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        SharedPreferences SharedPrefs = context.getSharedPreferences("Gemairo", 0);
+        String Bearer = SharedPrefs.getString("Tokens", "");
+        String SchoolURL = SharedPrefs.getString("SchoolURL", "");
+        String PersonID = SharedPrefs.getString("PersonID", "");
+        String latestgrades = SharedPrefs.getString("latestGrades", "");
+        try {
+          JSONObject Tokens = new JSONObject(Bearer);
+          final JSONObject latestGrades = new JSONObject(latestgrades);
+
+          String CompleteURL = "https://" + SchoolURL.replaceAll("\"", "") + "/api/personen/" + PersonID
+              + "/cijfers/laatste?top=50&skip=0";
+          try {
+            URL url = new URL(CompleteURL);
+            StringBuffer content = new StringBuffer();
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("GET");
+            con.setRequestProperty("Content-Type", "application/json");
+            con.setRequestProperty("Authorization", "Bearer " + Tokens.getString("access_token"));
+            con.setRequestProperty("noCache", java.time.Clock.systemUTC().instant().toString());
+            con.setRequestProperty("x-requested-with", "app.netlob.magiscore");
+            try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(con.getInputStream()))) {
+              for (String line; (line = reader.readLine()) != null;) {
+                content.append(line);
+              }
+            }
+            String result = content.toString();
+            final JSONObject jsonresult = new JSONObject(result);
+            Log.d(BackgroundFetch.TAG, "Are latestgrade object's the same? "
+                + jsonresult.getString("items").equals(latestGrades.getString("items")));
+            if (!jsonresult.getString("items").equals(latestGrades.getString("items"))) {
+              NotificationManager mNotificationManager;
+
+              NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context.getApplicationContext(),
+                  "Gemairo");
+              Intent ii = new Intent(context.getPackageManager().getLaunchIntentForPackage("app.netlob.magiscore"));
+              PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, ii,
+                  PendingIntent.FLAG_UPDATE_CURRENT);
+
+              NotificationCompat.BigTextStyle bigText = new NotificationCompat.BigTextStyle();
+              bigText.bigText("Nieuwe cijfer(s) beschikbaar");
+              bigText.setBigContentTitle("Nieuwe cijfers in Gemairo");
+
+              mBuilder.setContentIntent(pendingIntent);
+              mBuilder.setSmallIcon(R.drawable.notification);
+              mBuilder.setContentTitle("Nieuwe cijfers in Gemairo");
+              mBuilder.setContentText("Nieuwe cijfer(s) beschikbaar");
+              mBuilder.setPriority(Notification.PRIORITY_HIGH);
+              mBuilder.setStyle(bigText);
+              mBuilder.setAutoCancel(true);
+              mBuilder.setOnlyAlertOnce(true);
+
+              mNotificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                String channelId = "Gemairo-Cijfers";
+                NotificationChannel channel = new NotificationChannel(
+                    channelId,
+                    "Cijfers",
+                    NotificationManager.IMPORTANCE_DEFAULT);
+                mNotificationManager.createNotificationChannel(channel);
+                mBuilder.setChannelId(channelId);
+              }
+
+              mNotificationManager.notify(0, mBuilder.build());
+            }
+            BackgroundFetch.getInstance(context).finish(taskId);
+          } catch (Exception ex) {
+            ex.printStackTrace();
+            Log.d(BackgroundFetch.TAG, Log.getStackTraceString(ex));
+            BackgroundFetch.getInstance(context).finish(taskId);
+          }
+        } catch (JSONException e) {
+          e.printStackTrace();
+          Log.d(BackgroundFetch.TAG, Log.getStackTraceString(e));
+          BackgroundFetch.getInstance(context).finish(taskId);
+        }
+      }
+    });
+    thread.start();
+    BackgroundFetch.getInstance(context).finish(taskId);
+  }
+}

--- a/app/Magiscore/config.xml
+++ b/app/Magiscore/config.xml
@@ -60,6 +60,7 @@
             target="app/src/main/res/drawable-xxhdpi/notification.png" />
         <resource-file src="res/new/res/notification/drawable-xxxhdpi/notification.png"
             target="app/src/main/res/drawable-xxxhdpi/notification.png" />
+        <resource-file src="BackgroundFetchHeadlessTask.java" target="app/src/main/java/com/transistorsoft/cordova/backgroundfetch/BackgroundFetchHeadlessTask.java" />
     </platform>
     <platform name="ios">
         <resource-file src="GoogleService-Info.plist" />

--- a/app/Magiscore/package.json
+++ b/app/Magiscore/package.json
@@ -17,6 +17,7 @@
     "admob-plus-cordova": "1.28.0",
     "at-least-node": "^1.0.0",
     "cordova-annotated-plugin-android": "1.0.4",
+    "cordova-plugin-awesome-shared-preferences": "^0.1.0",
     "cordova-plugin-background-fetch": "^7.1.2",
     "cordova-plugin-badge-fix": "^0.8.10",
     "cordova-launch-review": "^3.1.1",
@@ -33,6 +34,7 @@
     "cordova-plugin-splashscreen": "^5.0.3",
     "cordova-plugin-statusbar": "^2.4.3",
     "cordova-plugin-taptic-engine": "^2.1.0",
+    "cordova-plugin-theme-detection": "^1.3.0",
     "cordova-plugin-vibration": "^3.1.1",
     "cordova-plugin-whitelist": "1",
     "fast-glob": "^3.2.4",
@@ -85,7 +87,12 @@
         "ANDROIDX_VERSION": "1.2.0",
         "ANDROIDX_APPCOMPAT_VERSION": "1.3.1"
       },
-      "cordova-plugin-background-fetch": {}
+      "cordova-plugin-background-fetch": {},
+      "cordova-plugin-advanced-http": {
+        "ANDROIDBLACKLISTSECURESOCKETPROTOCOLS": "SSLv3,TLSv1"
+      },
+      "cordova-plugin-awesome-shared-preferences": {},
+      "cordova-plugin-theme-detection": {}
     },
     "platforms": [
       "android",

--- a/app/Magiscore/www/css/main.css
+++ b/app/Magiscore/www/css/main.css
@@ -644,6 +644,13 @@ a.magister-login:before {
 display: none;
 }
 
+.buttoncheckbox > input {
+  float: left;
+  accent-color: var(--primary);
+  margin-right: 5px;
+}
+
+
 .buttoncheckbox {
   border: var(--primary) 2px solid;
   padding: 5px;
@@ -687,7 +694,7 @@ display: none;
     align-items: center;
 }
 
-.snackbarContainer > .snackbar {
+/* .snackbarContainer > .snackbar {
     min-width: 250px;
     margin-left: unset!important;
     background-color: white;
@@ -718,6 +725,38 @@ display: none;
 
 .snackbarContainer > .snackbar > .text-warning:hover {
   color: var(--indigo)!important;
+} */
+
+.snackbarContainer > .snackbar {
+  min-width: 250px;
+  text-align: center;
+  margin-left: unset!important;
+  position: relative!important;
+  left: unset!important;
+  bottom: unset!important;
+  animation-name: slidein;
+  animation-duration: 500ms;
+  -webkit-box-shadow: 0 0.25rem 0.75rem rgb(0 0 0 / 10%);
+  box-shadow: 0 0.25rem 0.75rem rgb(0 0 0 / 10%);
+  backdrop-filter: blur(10px);
+  background-clip: padding-box;
+  background-color: rgba(255, 255, 255, 0.85);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  font-weight: bold;
+  color: #333;
+}
+
+.snackbarContainer > .snackbar > .text-warning {
+  color: var(--primary)!important;
+}
+
+.radio-options input[type="radio"]:checked+label {
+  text-decoration: underline;
+  text-underline-position: under;
+  text-decoration-thickness: 2px;
 }
 
 .reverseanimation {

--- a/app/Magiscore/www/index.html
+++ b/app/Magiscore/www/index.html
@@ -1222,6 +1222,14 @@
           "Probleem bij het inloggen",
           ["Aanmelden", "Uitloggen"]
         );
+        if (viewController.config.devMode) {
+    (async () => { var appVersion = await cordova.getAppVersion.getVersionNumber();
+    viewController.toast(
+    '<span class="float-left">Er is iets fout gegaan! </span><a class="float-right vibrate text-warning" href="https://github.com/netlob/magiscore/issues/new?body=' + encodeURIComponent(
+    `#### Wat ging er fout?\n\n#### Automatisch gevonden informatie:\nUseragent: ${navigator.userAgent}\nVersie: ${appVersion}\n\n#### Gevonden error:\n\`\`\`\n${error}\n\`\`\``) +'">RAPPORTEER</a>',
+    10000,
+    true
+  );})();}
       return false;
     }
   </script>

--- a/app/Magiscore/www/index.html
+++ b/app/Magiscore/www/index.html
@@ -418,12 +418,16 @@
 
           <h6 class="ml-1 pl-3 font-weight-bold text-primary">Gemairo</h6>
           <ul class="list-group list-group-flush">
-            <li class="list-group-item shadow mb-2">Thema <a class="float-right menu-a ml-2 vibrate"
-                onclick="viewController.darkTheme()">DONKER</a><a class="float-right menu-a vibrate"
-                onclick="viewController.lightTheme()">LICHT</a>
+
+            <li class="list-group-item shadow mb-2 radio-options">Thema
+              <div style="position: absolute;display: inline-block;right: 20px;background: inherit;">
+                <input id="Themad" style="display: none;" type="radio" name="themerad"><label onclick="viewController.updateConfig({autoTheme: false});viewController.darkTheme()" for="Themad" class="float-right menu-a ml-2 vibrate mb-0">DONKER</label>
+                <input id="Themal" style="display: none;" type="radio" name="themerad"><label onclick="viewController.updateConfig({autoTheme: false});viewController.lightTheme()" for="Themal" class="float-right menu-a ml-2 vibrate mb-0">LICHT</label>
+                <input id="Themaa" style="display: none;" type="radio" name="themerad"><label onclick="viewController.updateConfig({autoTheme: true}); viewController.initTheme();" for="Themaa" class="float-right menu-a ml-2 vibrate mb-0">AUTO</label>   
+              </div>
             </li>
             <li class="list-group-item shadow mb-2">Profielfoto
-              <a class="float-right menu-a ml-2 vibrate" onclick="setProfilePic(true)">
+              <a class="float-right menu-a ml-2 vibrate" onclick="setProfilePic(true, getActiveChildAccount())">
                 <i class="far fa-sync-alt fa-sm"></i>
               </a>
               <a class="float-right menu-a ml-2 vibrate"
@@ -434,6 +438,13 @@
                 Is je schoolfoto niet zo goed gelukt? Dan kun je een coole smiley als profielfoto gebruiken! Druk op <i
                   class="far fa-sync-alt fa-s"></i> om je schoolfoto te refreshen
               </span>
+            </li>
+            <li class="list-group-item shadow mb-2 radio-options">Decimaal scheidingsteken
+              <div style="position: absolute;display: inline-block;right: 20px;background: inherit;">
+                <input id="rad1" style="display: none;" type="radio" name="separatorrad"><label onclick="viewController.updateConfig({separator: 'nl-nl'});" for="rad1" class="float-right menu-a ml-2 vibrate mb-0">KOMMA</label>
+                <input id="rad2" style="display: none;" type="radio" name="separatorrad"><label onclick="viewController.updateConfig({separator: 'en-us'});" for="rad2" class="float-right menu-a ml-2 vibrate mb-0">PUNT</label>
+                <input id="rad3" style="display: none;" type="radio" name="separatorrad"><label onclick="viewController.updateConfig({separator: undefined});" for="rad3" class="float-right menu-a ml-2 vibrate mb-0">AUTO</label>   
+              </div>
             </li>
             <li class="list-group-item shadow mb-2 d-inline-block">Developer
               mode</i>
@@ -1029,7 +1040,7 @@
             </div>
             </div>
             <div class="modal-footer">
-              <button type="button" onClick="filtereddisabled = [];document.getElementById('gradefilterbutton').children[0].children[0].classList.remove('activefilter');viewController.render(viewController.currentLesson);viewController.updateNav();" class="btn btn-secondary vibrate" data-dismiss="modal">Reset</button>
+              <button type="button" onClick="filtereddisabled = [];document.getElementById('gradefilterbutton').children[0].children[0].classList.remove('activefilter');if (!(document.getElementById('search-wrapper').style.display != 'none')){viewController.render(viewController.currentLesson); }viewController.updateNav();" class="btn btn-secondary vibrate" data-dismiss="modal">Reset</button>
               <button type="button" class="btn btn-secondary vibrate" data-dismiss="modal">Sluiten</button>
               <button type="button" onClick="generateFilter();" data-dismiss="modal" class="btn btn-primary vibrate">Bereken</button>
             </div>

--- a/app/Magiscore/www/index.html
+++ b/app/Magiscore/www/index.html
@@ -1216,7 +1216,12 @@
       $("#overlay").hide()
       logConsole(`[ERROR] ${msg} line: ${lineNo}\n url: ${url}`)
       console.error(msg, url, lineNo, columnNo, error)
-      if ($("#mobilePersonInfo").text() == "Voornaam Achternaam") openBrowser(1)
+      if ($("#mobilePersonInfo").text() == "Voornaam Achternaam") navigator.notification.confirm(
+          'Er is iets fout gegaan waardoor je geen toegang hebt tot dit account. Probeer opnieuw aan te melden door op de knop ‘Aanmelden’ te klikken of log uit door op de knop ‘Uitloggen’ te klikken.',
+          openBrowser,
+          "Probleem bij het inloggen",
+          ["Aanmelden", "Uitloggen"]
+        );
       return false;
     }
   </script>

--- a/app/Magiscore/www/index.html
+++ b/app/Magiscore/www/index.html
@@ -542,6 +542,12 @@
                     <button onClick="generateSearch(document.getElementById('zoekBalk').value)" class="btn" style="color: black!important;">
                       <i data-toggle="modal" data-target="#zoekModal" class="fas fa-search fa-sm fa-fw text-gray-400"></i>
                     </button>
+                    <button id="SearchToGeneral" onClick="generateSearch(document.getElementById('zoekBalk').value, true)" class="btn" style="color: black!important;">
+                      <i class="fas fa-chart-bar fa-sm fa-fw text-gray-400"></i>
+                    </button>
+                    <button id="searchfilterbutton" data-toggle="modal" data-target="#vakkenModal" class="btn" style="display: none; color: black!important;">
+                      <i class="fas fa-filter fa-sm fa-fw text-gray-400"></i>
+                    </button>
                   </div>
                   <hr class="m-0 p-0">
                   <div class="p-0" id="zoekGradesTable">
@@ -1040,9 +1046,19 @@
             </div>
             </div>
             <div class="modal-footer">
-              <button type="button" onClick="filtereddisabled = [];document.getElementById('gradefilterbutton').children[0].children[0].classList.remove('activefilter');if (!(document.getElementById('search-wrapper').style.display != 'none')){viewController.render(viewController.currentLesson); }viewController.updateNav();" class="btn btn-secondary vibrate" data-dismiss="modal">Reset</button>
+              <button type="button" onClick="filtereddisabled = []; 
+              document.getElementById('gradefilterbutton').children[0].children[0].classList.remove('activefilter'); 
+              if (!(document.getElementById('search-wrapper').style.display != 'none')) {
+                 viewController.render(viewController.currentLesson); 
+                 viewController.updateNav();
+                } else if (viewController.currentLesson == 'generalAll') {
+                  filtereddisabled = filteredsearched;
+                  viewController.render(viewController.currentLesson); 
+                  [...document.getElementById('periodeModalTable').children].forEach((ch) => { if (ch.tagName = 'LABEL') ch.children[0].checked = true; });
+                  [...document.getElementById('vakkenModalTable').children].forEach((ch) => { if (ch.tagName = 'LABEL') ch.children[0].checked = true; });
+                }" class="btn btn-secondary vibrate" data-dismiss="modal">Reset</button>
               <button type="button" class="btn btn-secondary vibrate" data-dismiss="modal">Sluiten</button>
-              <button type="button" onClick="generateFilter();" data-dismiss="modal" class="btn btn-primary vibrate">Bereken</button>
+              <button type="button" onClick="generateFilter();" data-dismiss="modal" id="calculateFilter" class="btn btn-primary vibrate">Bereken</button>
             </div>
             </div>
             </div>

--- a/app/Magiscore/www/js/ads.js
+++ b/app/Magiscore/www/js/ads.js
@@ -101,7 +101,7 @@ const ads = {
   },
 
   async loadBanner() {
-    if (_banner != undefined || window.location.hash == "#noNewAds") {
+    if (_banner != undefined || window.location.hash == "#noNewAds" || document.hidden) {
       // banner already loaded
       return;
     }

--- a/app/Magiscore/www/js/ads.js
+++ b/app/Magiscore/www/js/ads.js
@@ -101,7 +101,7 @@ const ads = {
   },
 
   async loadBanner() {
-    if (_banner != undefined) {
+    if (_banner != undefined || window.location.hash == "#noNewAds") {
       // banner already loaded
       return;
     }

--- a/app/Magiscore/www/js/classes/Lesson.js
+++ b/app/Magiscore/www/js/classes/Lesson.js
@@ -307,7 +307,7 @@ class Lesson {
         }
       }
     });
-    $("#newGrade-newGrade").text(parseFloat(round(newGrade)).toLocaleString(undefined, {minimumFractionDigits: 2,maximumFractionDigits: 2}));
+    $("#newGrade-newGrade").text(parseFloat(round(newGrade)).toLocaleString(viewController.config.separator, {minimumFractionDigits: 2,maximumFractionDigits: 2}));
     return round(newGrade);
   }
 

--- a/app/Magiscore/www/js/classes/Lesson.js
+++ b/app/Magiscore/www/js/classes/Lesson.js
@@ -245,7 +245,7 @@ class Lesson {
     var alles = 0;
     var totaalweging = 0;
     for (var i = 0; i < grades.length; i++) {
-      if (!grades[i].exclude) {
+      if (!grades[i].exclude && !filtereddisabled.includes(grades[i])) {
         var cijfer = grades[i].grade.replace(",", ".");
         cijfer = Number(cijfer);
         alles += cijfer * grades[i].weight;

--- a/app/Magiscore/www/js/controllers/CourseController.js
+++ b/app/Magiscore/www/js/controllers/CourseController.js
@@ -58,8 +58,9 @@ class CourseController {
       // logConsole("RAW:")
       // logConsole(JSON.stringify(this.raw))
       var personid = (childindex >= 0 && person.isParent) ? person.children[childindex].Id : person.id
-      const url = `https://cors.sjoerd.dev/https://${school}/api/personen/${personid}/cijfers/laatste?top=50&skip=0`;
+      const url = `https://${school}/api/personen/${personid}/cijfers/laatste?top=50&skip=0`;
       //Er wordt hier een plugin gebruikt, omdat die in Chrome niet worden gethrottled wanneer de applicatie zich in de achtergrond bevindt.
+      //Ook heeft de plugin geen CORS beperkingen.
       cordova.plugin.http.sendRequest(url, {
         headers: {
           accept: "application/json, text/plain, */*",

--- a/app/Magiscore/www/js/controllers/CourseController.js
+++ b/app/Magiscore/www/js/controllers/CourseController.js
@@ -73,6 +73,7 @@ class CourseController {
         var res = JSON.parse(response.data);
         var grades = res.Items || res.items;
         courseController.latestGrades = grades;
+        window.dispatchEvent( new Event('storage') );
         var popup = false;
         var foundnew = false
         //Voor een of andere reden is het kolomId van sommige cijfers anders wanneer het bij de laatste cijfers opgehaald wordt,

--- a/app/Magiscore/www/js/controllers/ViewController.js
+++ b/app/Magiscore/www/js/controllers/ViewController.js
@@ -133,8 +133,8 @@ class ViewController {
         ? '<span class="text-danger">' + grade.grade + "</span>"
         : grade.grade
     }`);
-    $("#grade-modal-weight").text(grade.weight);
-    $("#grade-modal-weight2").text(grade.weight);
+    $("#grade-modal-weight").text(grade.weight.toLocaleString(viewController.config.separator));
+    $("#grade-modal-weight2").text(grade.weight.toLocaleString(viewController.config.separator));
     $("#grade-modal-description").text(
       grade.description == ""
         ? "<i>Geen beschrijving...</i>"
@@ -293,7 +293,7 @@ class ViewController {
         this.toast("Profielfoto veranderd naar originele foto", 2000, false);
     }
     $('#useraccountslist').html(``);
-    $('#useraccountslist').append(`<a class="dropdown-item vibrate" onclick="window.location = './login.html'"><i class="fas fa-plus fa-sm fa-fw mr-2 text-gray-400"></i>Voeg nog een account toe</a>`)
+    $('#useraccountslist').append(`<a class="dropdown-item vibrate" href="login.html#addextra"><i class="fas fa-plus fa-sm fa-fw mr-2 text-gray-400"></i>Voeg nog een account toe</a>`)
     var activeaccount = parseInt(getActiveAccount());
     for (const key of Object.keys(localStorage).filter((key) => !isNaN(key))) {
       var persondata = JSON.parse(getObject("person", key));
@@ -403,11 +403,11 @@ class ViewController {
     $(".snackbar").remove();
   }
 
-  initTheme() {
-    var theme = this.config.darkTheme;
+  async initTheme() {
+    var theme = this.config.autoTheme ? await this.nativeDarkModeEnabled() : this.config.darkTheme;
     var darkThemeDevice = false;
     try {
-      darkThemeDevice = cordova.plugins.ThemeDetection.isDarkModeEnabled();
+      darkThemeDevice = await this.nativeDarkModeEnabled();
     } catch (e) {}
     // var theme = window.matchMedia('(prefers-color-scheme:dark)').matches;
     var darkThemeDevice = false;
@@ -430,17 +430,17 @@ class ViewController {
     // }
   }
 
-  overlay(state) {
+  async overlay(state) {
     // if (cordova.platformId == 'android') {
     if (state == "show") {
       $("#overlay").show();
-      if (this.config.darkTheme)
+      if (this.config.autoTheme ? (await this.nativeDarkModeEnabled()) : this.config.darkTheme)
         StatusBar.backgroundColorByHexString("#161618");
       else StatusBar.backgroundColorByHexString("#7f7f7f");
     }
     if (state == "hide") {
       $("#overlay").hide();
-      if (this.config.darkTheme)
+      if (this.config.autoTheme ? (await this.nativeDarkModeEnabled()) : this.config.darkTheme)
         StatusBar.backgroundColorByHexString("#2c2d30");
       else StatusBar.backgroundColorByHexString("#ffffff");
     }
@@ -462,6 +462,12 @@ class ViewController {
         isDesktop: this.config.isDesktop,
       });
     }
+  }
+
+  nativeDarkModeEnabled() {
+    return new Promise((resolve, reject) => {
+    cordova.plugins.ThemeDetection.isAvailable(function(data) {if (data.value) {cordova.plugins.ThemeDetection.isDarkModeEnabled(function(data) {return resolve(data.value)})} else (resolve(false));})
+    })
   }
 
   clearExclude() {
@@ -874,7 +880,7 @@ function updateSidebar() {
     }`
   );
   $('#useraccountslist').html(``);
-  $('#useraccountslist').append(`<a class="dropdown-item vibrate" onclick="window.location = './login.html'"><i class="fas fa-plus fa-sm fa-fw mr-2 text-gray-400"></i>Voeg nog een account toe</a>`)
+  $('#useraccountslist').append(`<a class="dropdown-item vibrate" href="login.html#addextra"><i class="fas fa-plus fa-sm fa-fw mr-2 text-gray-400"></i>Voeg nog een account toe</a>`)
   var activeaccount = parseInt(getActiveAccount());
   for (const key of Object.keys(localStorage).filter((key) => !isNaN(key))) {
     var persondata = JSON.parse(getObject("person", key));
@@ -1152,7 +1158,7 @@ function setChartData(config, lesson, everything) {
         caretPadding: 4,
         callbacks: {
           label: function(tooltipItem, data) {
-              return `${data.datasets[tooltipItem.datasetIndex].label}: ${tooltipItem.yLabel.toLocaleString()}`;
+              return `${data.datasets[tooltipItem.datasetIndex].label}: ${tooltipItem.yLabel.toLocaleString(viewController.config.separator)}`;
           }
         }
       },
@@ -1224,8 +1230,8 @@ function setChartData(config, lesson, everything) {
 
   if (vol + onvol > 0) {
     var tot = vol + onvol;
-    vol = parseFloat(round((vol / tot) * 100)).toLocaleString(undefined, {minimumFractionDigits: 2,maximumFractionDigits: 2});
-    onvol = parseFloat(round((onvol / tot) * 100)).toLocaleString(undefined, {minimumFractionDigits: 2,maximumFractionDigits: 2});
+    vol = parseFloat(round((vol / tot) * 100)).toLocaleString(viewController.config.separator, {minimumFractionDigits: 2,maximumFractionDigits: 2});
+    onvol = parseFloat(round((onvol / tot) * 100)).toLocaleString(viewController.config.separator, {minimumFractionDigits: 2,maximumFractionDigits: 2});
     $("#percentageGrades").text(`${vol}% voldoende - ${onvol}% onvoldoende`);
   } else {
     $("#percentageGrades").text(`Geen cijfers voor dit vak...`);
@@ -1386,7 +1392,7 @@ function setChartData(config, lesson, everything) {
           caretPadding: 4,
           callbacks: {
             label: function(tooltipItem, data) {
-                return `${data.datasets[tooltipItem.datasetIndex].label}: ${tooltipItem.yLabel.toLocaleString()}`;
+                return `${data.datasets[tooltipItem.datasetIndex].label}: ${tooltipItem.yLabel.toLocaleString(viewController.config.separator)}`;
             }
           }
         },
@@ -1521,7 +1527,7 @@ function setChartData(config, lesson, everything) {
                 var meta = chartInstance.controller.getDatasetMeta(i);
                 meta.data.forEach(function (bar, index) {
                   var data =
-                    (Math.round(parseFloat(dataset.data[index]) * 10) / 10).toLocaleString();
+                    (Math.round(parseFloat(dataset.data[index]) * 10) / 10).toLocaleString(viewController.config.separator);
                   ctx.fillStyle = "#6e707e";
                   ctx.fillText(data, bar._model.x, bar._model.y + 15);
                 });
@@ -1630,18 +1636,18 @@ function setAllGrades() {}
 function toShortFormat(d) {
   d = new Date(d);
   var month_names = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "Mei",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Okt",
-    "Nov",
-    "Dec",
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "mei",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "okt",
+    "nov",
+    "dec",
   ];
   return `${d.getDate()} ${month_names[d.getMonth()]} ${d.getFullYear()}`; //7:05, 21 Jul 2020'
 }
@@ -1684,16 +1690,16 @@ function setTableData(lesson) {
         })" ${(grade.exclude) ? 'style="opacity:0.5 !important;"' : ""}>
           <div class="dropdown-list-image mr-1" style="margin-bottom: -9px">
             <div class="rounded-circle">
-              <h4 class="text-center mt-2">${
+              <h4 class="text-center mt-2 mr-3" style="position: relative;">${
                 grade.grade == "10,0"
                   ? '<span class="text-success">10</span><span class="invisible">,</span>'
                   : !grade.passed
                   ? '<span class="text-danger">' + grade.grade + "</span>"
                   : grade.grade
-              }<sup class="text-gray-800" style="font-size: 10px !important; top: -2em !important; font-variant-numeric: tabular-nums !important;">${
+              }<sup class="text-gray-800" style="font-size: 10px !important;position: absolute;margin-top: 5px;right: -1rem;display: inline-block;font-variant-numeric: tabular-nums !important;">${
         grade.weight < 10
-          ? grade.weight + 'x<span class="invisible">0</span>'
-          : grade.weight + "x"
+          ? grade.weight.toLocaleString(viewController.config.separator) + 'x<span class="invisible">0</span>'
+          : grade.weight.toLocaleString(viewController.config.separator) + "x"
       }</sup></h4>
             </div>
             <!-- <div class="status-indicator bg-success"></div> -->
@@ -1733,7 +1739,7 @@ function setAverages() {
       $("#averagesTable").append(
         `<tr onclick="viewController.render('${lesson.name}')">
           <td>${lesson.name}</td>
-          <td>${(Math.round(average * 100) / 100).toLocaleString()}</td>
+          <td>${(Math.round(average * 100) / 100).toLocaleString(viewController.config.separator)}</td>
          </tr>`
       );
       totgem = totgem + parseFloat(average);
@@ -1742,7 +1748,7 @@ function setAverages() {
   });
   var totgem = totgem / totgemclass;
   $("#general-average").text(
-    `${round(totgem) == "NaN" ? "Geen cijfers..." : parseFloat(round(totgem)).toLocaleString(undefined, {minimumFractionDigits: 2,maximumFractionDigits: 2})}`
+    `${round(totgem) == "NaN" ? "Geen cijfers..." : parseFloat(round(totgem)).toLocaleString(viewController.config.separator, {minimumFractionDigits: 2,maximumFractionDigits: 2})}`
   );
 }
 
@@ -1777,7 +1783,7 @@ function generateHTML(lesson) {
                     <div class="row no-gutters align-items-center">
                     <div class="col mr-2">
                         <div class="text-xs font-weight-bold text-primary-blue text-uppercase mb-1">Gemiddeld cijfer</div>
-                        <div class="h5 mb-0 font-weight-bold text-gray-800">${parseFloat(average).toLocaleString(undefined, {minimumFractionDigits: 2,maximumFractionDigits: 2})}</div>
+                        <div class="h5 mb-0 font-weight-bold text-gray-800">${parseFloat(average).toLocaleString(viewController.config.separator, {minimumFractionDigits: 2,maximumFractionDigits: 2})}</div>
                     </div>
                     <div class="col-auto">
                         <i class="fas fa-graduation-cap fa-2x text-gray-300"></i>

--- a/app/Magiscore/www/js/controllers/ViewController.js
+++ b/app/Magiscore/www/js/controllers/ViewController.js
@@ -719,6 +719,7 @@ class ViewController {
   }
 
   openZoeken() {
+    filtereddisabled = [];
     viewController.settingsOpen = true;
     $("#buttonSidenavToggle").hide();
     $("#buttonSidenavBack").show();

--- a/app/Magiscore/www/js/login.js
+++ b/app/Magiscore/www/js/login.js
@@ -611,7 +611,8 @@ async function verderGaanLogin(childindex = -1, last = false, m) {
     activelocalstorage = JSON.parse(localStorage.getItem(newaccountindex));
     delete activelocalstorage.childcourses;
     localStorage.setItem(newaccountindex, JSON.stringify(activelocalstorage));
-    window.location.replace("./index.html");
+    window.dispatchEvent( new Event('storage') )
+    window.location.replace((history.length != 0 && Object.keys(localStorage).filter((key) => !isNaN(key)).length != 0) ? "./index.html#noNewAds" : "./index.html");
   };
 }
 

--- a/app/Magiscore/www/js/login.js
+++ b/app/Magiscore/www/js/login.js
@@ -324,14 +324,15 @@ async function validateLogin(code, codeVerifier) {
       setObject("tokens", JSON.stringify(tokens), newaccountindex);
 
       const res = await fetch(
-        "https://cors.sjoerd.dev/https://magister.net/.well-known/host-meta.json",
+        "https://cors.sjoerd.dev/https://magister.net/.well-known/host-meta.json?rel=magister-api",
         {
           headers: new Headers({
             Authorization: `Bearer ${tokens.access_token}`,
           }),
         }
       ).then((res) => res.json());
-      tenant = JSON.stringify(res).match(/(?!(w+)\.)\w*(?:\w+\.)+\w+/)[0];
+      tenant = JSON.stringify(res).match(/(?!(w+)\.)[a-zA-Z0-9_\-]*(?:\w+\.)+\w+/)[0];
+      logConsole(`${tenant} gevonden.`);
       setObject("school", tenant, newaccountindex);
       var config = {
         isDesktop: false,

--- a/app/Magiscore/www/js/main.js
+++ b/app/Magiscore/www/js/main.js
@@ -750,7 +750,7 @@ function onDeviceReady() {
   
     var onEvent = async function(taskId) {
         console.log('[BackgroundFetch] event received: ', taskId);
-        await refreshToken();
+        await refreshToken(true);
         var latestgrades = await courseController.getLatestGrades(false, getActiveChildAccount(), true);
         console.log(latestgrades[1] ? 'New grades found' : "No new grades found")
         if (latestgrades[1]) sendNotification();

--- a/app/Magiscore/www/js/main.js
+++ b/app/Magiscore/www/js/main.js
@@ -326,7 +326,7 @@ async function syncGrades() {
           newGrades.length
         }</span> van je ${
               viewController.config.refreshOldGrades ? "" : " nieuwe"
-            } cijfers gesynced<br><!-- <i
+            } cijfers gesynchroniseerd<br><!-- <i
         class="far fa-info-circle fa-s display-inline-block mr-3 ml-2 mb-2 mt-3"> Refresh oude cijfers is ingeschakeld, alle cijfers worden gerefreshed --></span>`,
             false,
             true
@@ -384,7 +384,7 @@ async function syncGrades() {
                 });
                 viewController.toast(
                   `
-                <b class="mb-0">${newGrades.length} nieuwe cijfers gesycned!</b>
+                <b class="mb-0">${newGrades.length} nieuwe cijfers gesynchroniseerd!</b>
                 ${extra}
               `,
                   7000,
@@ -589,15 +589,23 @@ function generateFilter() {
 
   document.getElementById('gradefilterbutton').children[0].children[0].classList.add("activefilter");
 
-  viewController.render(viewController.currentLesson);
+  if (!(document.getElementById('search-wrapper').style.display != 'none')) viewController.render(viewController.currentLesson);
   updateSidebar();
 }
 
 function generateSearch(Zoekopdracht) {
   var zoektable = $("#zoekGradesTable")
   zoektable.empty();
-  var searched = courseController.allGrades.filter((grade) => Object.entries(grade).map((grade) => {if (grade[0].includes('grade') || grade[0].includes('description')) {return grade[1] } else if (grade[0].includes('teacher')) {return grade[1].teacherCode} else if (grade[0].includes('class')) {return grade[1].description}}).filter((grade) => typeof grade != 'undefined').filter((string) => string != null && string.toString().toLowerCase()
-  .includes(Zoekopdracht.toString().toLowerCase())).length > 0);
+  var searched = _.sortBy(courseController.allGrades.filter((grade) => Object.entries(grade).map((grade) => {if (grade[0].includes('grade') || grade[0].includes('description')) {return grade[1] } else if (grade[0].includes('teacher')) {return grade[1].teacherCode} else if (grade[0].includes('class')) {return grade[1].description}}).filter((grade) => typeof grade != 'undefined').filter((string) => string != null && string.toString().toLowerCase()
+  .includes(Zoekopdracht.toString().toLowerCase())).length > 0), "dateFilledIn");
+  if ([...document.getElementById('gradefilterbutton').children[0].children[0].classList].includes('activefilter')) 
+  zoektable.append(
+    `<a class="d-flex align-items-center border-bottom vibrate grade-card mt-2 mb-2" style="justify-content: space-between; font-weight: bold;">
+    <span class="float-left" style="color: var(--secondary);">
+      <i class="fas fa-exclamation-triangle mr-1"></i> 
+        Filter was actief!
+    </span><span class="float-right vibrate" data-toggle="modal" data-target="#vakkenModal" style="color: var(--primary);">AANPASSEN</span>
+    </a><hr class="m-0 p-0">`);
   searched.forEach((grade, index) => {
     if (
       grade.type._type == 1 &&
@@ -612,16 +620,16 @@ function generateSearch(Zoekopdracht) {
         })" ${(grade.exclude) ? 'style="opacity:0.5 !important;"' : ""}>
           <div class="dropdown-list-image mr-1" style="margin-bottom: -9px">
             <div class="rounded-circle">
-              <h4 class="text-center mt-2">${
+              <h4 class="text-center mt-2 mr-3" style="position: relative;">${
                 grade.grade == "10,0"
                   ? '<span class="text-success">10</span><span class="invisible">,</span>'
                   : !grade.passed
                   ? '<span class="text-danger">' + grade.grade + "</span>"
                   : grade.grade
-              }<sup class="text-gray-800" style="font-size: 10px !important; top: -2em !important; font-variant-numeric: tabular-nums !important;">${
+              }<sup class="text-gray-800" style="font-size: 10px !important;position: absolute;margin-top: 5px;right: -1rem;display: inline-block;font-variant-numeric: tabular-nums !important;">${
         grade.weight < 10
-          ? grade.weight + 'x<span class="invisible">0</span>'
-          : grade.weight + "x"
+          ? grade.weight.toLocaleString(viewController.config.separator) + 'x<span class="invisible">0</span>'
+          : grade.weight.toLocaleString(viewController.config.separator)+ "x"
       }</sup></h4>
             </div>
             <!-- <div class="status-indicator bg-success"></div> -->
@@ -670,10 +678,13 @@ function MoveToNewStorage() {
   }
   localStorage.clear();
   localStorage.setItem(0, JSON.stringify(newaccountStorage));
+  window.dispatchEvent( new Event('storage') )
   window.location = './index.html';
 }
 
 function onDeviceReady() {
+  var sharedPreferences = window.plugins.SharedPreferences.getInstance("Gemairo");
+  sharedPreferences.get("tokens", [], function (data) {setObject("tokens", JSON.stringify(data), getActiveAccount())})
   $.ajaxSetup({
     cache: false,
   });
@@ -710,8 +721,9 @@ function onDeviceReady() {
   
     var status = await BackgroundFetch.configure({
       minimumFetchInterval: 15,
-      requiredNetworkType: 1,
-      stopOnTerminate: false
+      requiredNetworkType: BackgroundFetch.NETWORK_TYPE_ANY,
+      stopOnTerminate: false,
+      enableHeadless: true
     }, onEvent, onTimeout);
     console.log('[BackgroundFetch] configure status: ', status);
   })();
@@ -902,14 +914,16 @@ function sluitMelding(id) {
   $(`#${id}`).hide();
 }
 
-function sendNotification(title = "Nieuwe cijfers in Gemairo", text = "Gemairo heeft nieuwe cijfers gevonden!") {
+function sendNotification(title = "Nieuwe cijfers in Gemairo", text = "Nieuwe cijfer(s) beschikbaar") {
   cordova.plugins.notification.local.hasPermission(function (granted) { 
     if (granted) {
       cordova.plugins.notification.local.schedule({
         title: title,
         text: text,
         foreground: true,
-        smallIcon: "res://notification"
+        smallIcon: "res://notification",
+        channelId: "Gemairo-Cijfers",
+        channelName: "Cijfers"
     });
     }
   });
@@ -934,6 +948,16 @@ $(window).on('hashchange', function() {
 //   alert("online")
 //   // viewController.toast("Je bent weer online!", false, false)
 // }
+
+window.addEventListener("storage", function () {
+  //Waarom is dit hier?
+  //Dit is zodat het java gedeelte altijd de juiste informatie heeft, om op de achtergrond zonder de app open te hebben de laatste cijfers kan controleren.
+  var sharedPreferences = window.plugins.SharedPreferences.getInstance("Gemairo")
+  if (courseController.latestGrades.length > 0) sharedPreferences.put("latestGrades", JSON.parse(`{"items": ${JSON.stringify(courseController.latestGrades)}}`));
+  sharedPreferences.put("Tokens", JSON.parse(getObject("tokens", getActiveAccount())));
+  sharedPreferences.put("PersonID", (getActiveChildAccount() >= 0 && person.isParent) ? person.children[getActiveChildAccount()].Id : person.id);
+  sharedPreferences.put("SchoolURL", getObject("school", getActiveAccount()));
+}, false);
 
 function onResume() {
   if (idletime != null && Math.abs(new Date() - new Date(idletime)) > (30 * 60000)) {

--- a/app/Magiscore/www/js/main.js
+++ b/app/Magiscore/www/js/main.js
@@ -599,7 +599,6 @@ function generateFilter(noreset = false) {
 
   if (!(document.getElementById('search-wrapper').style.display != 'none') || noreset) viewController.render(viewController.currentLesson);
   updateSidebar();
-  filtereddisabled = [];
 }
 
 function generateSearch(Zoekopdracht, rendergeneral = false) {

--- a/app/Magiscore/www/js/main.js
+++ b/app/Magiscore/www/js/main.js
@@ -749,7 +749,7 @@ function onDeviceReady() {
   
     var onEvent = async function(taskId) {
         console.log('[BackgroundFetch] event received: ', taskId);
-        await refreshToken(true);
+        tokens = await refreshToken(true);
         var latestgrades = await courseController.getLatestGrades(false, getActiveChildAccount(), true);
         console.log(latestgrades[1] ? 'New grades found' : "No new grades found")
         if (latestgrades[1]) sendNotification();

--- a/app/Magiscore/www/js/main.js
+++ b/app/Magiscore/www/js/main.js
@@ -682,9 +682,16 @@ function MoveToNewStorage() {
   window.location = './index.html';
 }
 
-function onDeviceReady() {
+function beforeDeviceReady() {
   var sharedPreferences = window.plugins.SharedPreferences.getInstance("Gemairo");
-  sharedPreferences.get("tokens", [], function (data) {setObject("tokens", JSON.stringify(data), getActiveAccount())})
+  sharedPreferences.get("Tokens", [], function (data) {
+    if (data != '' && Object.entries(data).length > 0 && tokens != data)
+      setObject("tokens", JSON.stringify(data), getActiveAccount());
+    onDeviceReady();
+    }, onDeviceReady)
+}
+
+function onDeviceReady() {
   $.ajaxSetup({
     cache: false,
   });
@@ -954,7 +961,7 @@ window.addEventListener("storage", function () {
   //Dit is zodat het java gedeelte altijd de juiste informatie heeft, om op de achtergrond zonder de app open te hebben de laatste cijfers kan controleren.
   var sharedPreferences = window.plugins.SharedPreferences.getInstance("Gemairo")
   if (courseController.latestGrades.length > 0) sharedPreferences.put("latestGrades", JSON.parse(`{"items": ${JSON.stringify(courseController.latestGrades)}}`));
-  sharedPreferences.put("Tokens", JSON.parse(getObject("tokens", getActiveAccount())));
+  if (Object.entries(JSON.parse(getObject("tokens", getActiveAccount()))).length > 0) sharedPreferences.put("Tokens", JSON.parse(getObject("tokens", getActiveAccount())));
   sharedPreferences.put("PersonID", (getActiveChildAccount() >= 0 && person.isParent) ? person.children[getActiveChildAccount()].Id : person.id);
   sharedPreferences.put("SchoolURL", getObject("school", getActiveAccount()));
 }, false);
@@ -972,7 +979,7 @@ function onPause() {
  idletime = new Date();
 }
 
-document.addEventListener("deviceready", onDeviceReady, false);
+document.addEventListener("deviceready", beforeDeviceReady, false);
 document.addEventListener("pause", onPause, false);
 document.addEventListener("resume", onResume, false);
 // document.addEventListener("offline", onOffline, false);

--- a/app/Magiscore/www/js/main.js
+++ b/app/Magiscore/www/js/main.js
@@ -175,6 +175,11 @@ async function confirmLogout(b) {
       //window.location = "./index.html";
     } else {
       clearObject(getActiveAccount());
+      var sharedPreferences = window.plugins.SharedPreferences.getInstance("Gemairo")
+      sharedPreferences.del("latestGrades");
+      sharedPreferences.del("Tokens");
+      sharedPreferences.del("PersonID");
+      sharedPreferences.del("SchoolURL");
       window.location = "./login.html";
     }
   } else return;

--- a/app/Magiscore/www/js/refresh.js
+++ b/app/Magiscore/www/js/refresh.js
@@ -25,7 +25,12 @@ function refreshToken() {
           try {
             // var response = JSON.parse(XMLHttpRequest.responseText);
             // if (response.error == "invalid_grant") {
-            openBrowser(1);
+              navigator.notification.confirm(
+                'Er is iets fout gegaan waardoor je geen toegang hebt tot dit account. Probeer opnieuw aan te melden door op de knop ‘Aanmelden’ te klikken of log uit door op de knop ‘Uitloggen’ te klikken.',
+                openBrowser,
+                "Probleem bij het inloggen",
+                ["Aanmelden", "Uitloggen"]
+              );
             // }
           } catch (err) {
             logConsole("[ERROR] " + err);
@@ -64,8 +69,7 @@ function refreshToken() {
 
 function openBrowser(b) {
   if (b == 2) {
-    clearObject(getActiveAccount());
-    window.location = "./login.html";
+    confirmLogout(1)
   }
   // viewController.overlay("show")
   school = /(.+:\/\/)?([^\/]+)(\/.*)*/i.exec(school)[2];

--- a/app/Magiscore/www/js/refresh.js
+++ b/app/Magiscore/www/js/refresh.js
@@ -2,7 +2,7 @@ var verifier = "";
 var tenant = "";
 var popup = null;
 
-function refreshToken() {
+function refreshToken(background = false) {
   return new Promise((resolve, reject) => {
     var tokens = JSON.parse(getObject("tokens", getActiveAccount()));
     var refresh_token = tokens.refresh_token;
@@ -21,7 +21,7 @@ function refreshToken() {
         grant_type: "refresh_token"
       },
       error: function (XMLHttpRequest, textStatus, errorThrown) {
-        if (XMLHttpRequest.status == 400 || XMLHttpRequest.status == "400") {
+        if (XMLHttpRequest.status == 400 || XMLHttpRequest.status == "400" && !background) {
           try {
             // var response = JSON.parse(XMLHttpRequest.responseText);
             // if (response.error == "invalid_grant") {

--- a/app/Magiscore/www/js/utils.js
+++ b/app/Magiscore/www/js/utils.js
@@ -18,6 +18,7 @@ function setObject(key,value,index) {
     var json = JSON.parse(localStorage.getItem(index) ?? JSON.stringify({}))
     json[key] = value;
     localStorage.setItem(index, JSON.stringify(json));
+    window.dispatchEvent( new Event('storage') );
 }
 
 function getObject(key,index) {
@@ -51,6 +52,7 @@ async function ForceSetFromStorage() {
     var allfiles = await listFiles();
     var file = (await allfiles.filter((file) => file.name == `${userkey}.json`))[0];
     localStorage.setItem(userkey, await readFile(file));
+    window.dispatchEvent( new Event('storage') );
     window.location = './index.html';
 }
 

--- a/app/Magiscore/www/login.html
+++ b/app/Magiscore/www/login.html
@@ -122,8 +122,7 @@
                     >Login via Magister</a
                   >
                   <a
-                  href="#"
-                  onclick="history.back();"
+                  href="index.html#noNewAds"
                   style="display: none;"
                   id="terugknop"
                   class="btn btn-secondary btn-user btn-block bg-gradiant-secondary"


### PR DESCRIPTION
Toevoegingen:
- Op Android kunnen er nu voor nieuwe cijfers gecontroleerd worden zelfs als de app geheel gesloten is.
- Snackbars zien er weer net uit. 
- Het is nu mogelijk om automatisch tussen donkere en lichte modus te switchen.
- Het is nu mogelijk om de decimale scheidingstekens los aan te passen.
- Het is nu mogelijk om opgezochte cijfers met grafieken te bekijken.
- Voor scholen die streepjes in de tenant gebruiken is het nu mogelijk om in te loggen. #60 

Nieuwe benodigde plug-ins: 
- cordova-plugin-awesome-shared-preferences
- cordova-plugin-theme-detection
- cordova-plugin-advanced-http