### PR TITLE
Terug naar oude manier om voor nieuwe cijfers controleren

### DIFF
--- a/app/Magiscore/BackgroundFetchHeadlessTask.java
+++ b/app/Magiscore/BackgroundFetchHeadlessTask.java
@@ -50,6 +50,7 @@ public class BackgroundFetchHeadlessTask implements HeadlessTask {
         String PersonID = SharedPrefs.getString("PersonID", "");
         String latestgrades = SharedPrefs.getString("latestGrades", "");
         try {
+          if (latestgrades == "" || PersonID == "" || SchoolURL == "" || Bearer =="") return;
           JSONObject Tokens = new JSONObject(Bearer);
           final JSONObject latestGrades = new JSONObject(latestgrades);
 
@@ -98,7 +99,7 @@ public class BackgroundFetchHeadlessTask implements HeadlessTask {
             HttpURLConnection con = (HttpURLConnection) url.openConnection();
             con.setRequestMethod("GET");
             con.setRequestProperty("Content-Type", "application/json");
-            con.setRequestProperty("Authorization", "Bearer " + Tokens.getString("access_token"));
+            con.setRequestProperty("Authorization", "Bearer " + tokenjsonresult.getString("access_token"));
             con.setRequestProperty("noCache", java.time.Clock.systemUTC().instant().toString());
             con.setRequestProperty("x-requested-with", "app.netlob.magiscore");
             try (BufferedReader reader = new BufferedReader(
@@ -111,7 +112,12 @@ public class BackgroundFetchHeadlessTask implements HeadlessTask {
             final JSONObject jsonresult = new JSONObject(result);
             Log.d(BackgroundFetch.TAG, "Are latestgrade object's the same? "
                 + jsonresult.getString("items").equals(latestGrades.getString("items")));
-            if (!jsonresult.getString("items").equals(latestGrades.getString("items"))) {
+            if (!(jsonresult.getString("items").length() == 0) && !jsonresult.getString("items").equals(latestGrades.getString("items"))) {
+              //Opslaan nieuwe cijfers
+              final JSONObject newlatestgrades = new JSONObject();
+              newlatestgrades.put("items", jsonresult.getString("items"));
+              editor.putString("latestGrades", newlatestgrades.toString());
+              editor.apply();
               // Als de twee objecten niet hetzelfde zijn stuurt hij een notificatie.
               NotificationManager mNotificationManager;
 

--- a/app/Magiscore/BackgroundFetchHeadlessTask.java
+++ b/app/Magiscore/BackgroundFetchHeadlessTask.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.net.Socket;
 import org.json.*;
 import org.json.JSONObject;
+import org.json.JSONArray;
 import java.lang.Object;
 import android.content.SharedPreferences;
 import com.transistorsoft.tsbackgroundfetch.BackgroundFetch;
@@ -110,9 +111,10 @@ public class BackgroundFetchHeadlessTask implements HeadlessTask {
             }
             String result = content.toString();
             final JSONObject jsonresult = new JSONObject(result);
-            Log.d(BackgroundFetch.TAG, "Are latestgrade object's the same? "
+            JSONArray latestGradesItems = (JSONArray) latestGrades.get("items");
+            Log.d(BackgroundFetch.TAG, latestGradesItems.length() + " - Are latestgrade object's the same? "
                 + jsonresult.getString("items").equals(latestGrades.getString("items")));
-            if (!(jsonresult.getString("items").length() == 0) && !jsonresult.getString("items").equals(latestGrades.getString("items"))) {
+            if (!(latestGradesItems.length() == 0) && !jsonresult.getString("items").equals(latestGrades.getString("items"))) {
               //Opslaan nieuwe cijfers
               final JSONObject newlatestgrades = new JSONObject();
               newlatestgrades.put("items", jsonresult.getString("items"));

--- a/app/Magiscore/BackgroundFetchHeadlessTask.java
+++ b/app/Magiscore/BackgroundFetchHeadlessTask.java
@@ -114,10 +114,10 @@ public class BackgroundFetchHeadlessTask implements HeadlessTask {
             JSONArray latestGradesItems = (JSONArray) latestGrades.get("items");
             Log.d(BackgroundFetch.TAG, latestGradesItems.length() + " - Are latestgrade object's the same? "
                 + jsonresult.getString("items").equals(latestGrades.getString("items")));
-            if (!(latestGradesItems.length() == 0) && !jsonresult.getString("items").equals(latestGrades.getString("items"))) {
+            if (latestGradesItems.length() != 0 && !jsonresult.getString("items").equals(latestGrades.getString("items"))) {
               //Opslaan nieuwe cijfers
               final JSONObject newlatestgrades = new JSONObject();
-              newlatestgrades.put("items", jsonresult.getString("items"));
+              newlatestgrades.put("items", jsonresult.get("items"));
               editor.putString("latestGrades", newlatestgrades.toString());
               editor.apply();
               // Als de twee objecten niet hetzelfde zijn stuurt hij een notificatie.
@@ -155,6 +155,12 @@ public class BackgroundFetchHeadlessTask implements HeadlessTask {
               }
 
               mNotificationManager.notify(0, mBuilder.build());
+            } else if (latestGradesItems.length() == 0) {
+              //Opslaan nieuwe cijfers
+              final JSONObject newlatestgrades = new JSONObject();
+              newlatestgrades.put("items", jsonresult.get("items"));
+              editor.putString("latestGrades", newlatestgrades.toString());
+              editor.apply();
             }
             BackgroundFetch.getInstance(context).finish(taskId);
           } catch (Exception ex) {

--- a/app/Magiscore/www/js/controllers/CourseController.js
+++ b/app/Magiscore/www/js/controllers/CourseController.js
@@ -83,7 +83,7 @@ class CourseController {
           if (
             (courseController.allGrades.map((grade) => `${new Date(grade.dateFilledIn).toISOString()};${grade.grade};${grade.weight};${grade.description}`)
             .filter((foundgrade) => foundgrade == `${new Date(grade.ingevoerdOp).toISOString()};${grade.waarde};${grade.weegfactor};${grade.omschrijving}`).length == 0) &&
-            popup == false
+            JSON.stringify(courseController.allGrades).indexOf(grade.kolomId) < 0 && popup == false
           ) {
             popup = true;
             foundnew = true;
@@ -94,12 +94,15 @@ class CourseController {
             );
           }
         });
-      } catch(e) {console.log(e)}
+      } catch(e) {
+        console.log(e)
+        reject()
+      }
         viewController.setLatestGrades(courseController.latestGrades, open);
         viewController.overlay("hide");
         resolve([courseController.latestGrades, foundnew]);
       }, function(response) {
-        console.log(response.data)
+        console.log(response.status, response.data)
         reject(response.error);
       })
     });

--- a/app/Magiscore/www/js/controllers/ViewController.js
+++ b/app/Magiscore/www/js/controllers/ViewController.js
@@ -996,7 +996,7 @@ function setChartData(config, lesson, everything) {
         });
     })
   } else {
-    lessonController.getLesson(lesson).lesson.grades.forEach((grade) => {
+    lessonController.getLesson(lesson).lesson.fillGradeAverages().forEach((grade) => {
       if (!grade.exclude && !filtereddisabled.includes(grade)) {
         var gradegrade = grade.grade.replace(",", ".");
         data.push({


### PR DESCRIPTION
- De oude manier van cijfers controleren was oorspronkelijk weggehaald, omdat deze niet altijd correct werkte. De nieuwe manier werkt schijnbaar voor sommige nog minder goed dan de oorspronkelijke, dus zijn ze nu beide actief, zodat ze elkaar controleren.
- Het gemiddelde was na een zoekopdracht niet meer correct te zien in de grafieken, dat is nu opgelost.

Aangezien ik geen toegang heb tot de logboeken van deze fouten en ze zelf ook niet kan nabootsen, is het lastig om ze op te lossen. Mocht er iemand zijn die dit wel heeft, verwelkom ik je om ernaar te kijken.